### PR TITLE
Fix critical Linux symlink issue causing exit code 127

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as https from 'https';
 import * as http from 'http';
+import { fixSymlinks } from './symlinkUtils';
 
 let piperProcess: ReturnType<typeof spawn> | undefined;
 let playerProcess: ReturnType<typeof spawn> | undefined;
@@ -434,6 +435,14 @@ export function activate(context: vscode.ExtensionContext): PiperTTSApi {
     console.log('Extension path:', context.extensionUri.fsPath);
     console.log('OS platform:', os.platform());
     console.log('OS architecture:', os.arch());
+    
+    // Fix symbolic links on Linux platforms before doing anything else
+    if (os.platform() === 'linux') {
+        fixSymlinks(context.extensionUri.fsPath).catch(error => {
+            console.error('Failed to fix symbolic links:', error);
+            // Continue execution even if symlink fix fails
+        });
+    }
     
     // Set execute permissions for Linux and macOS binaries
     if (os.platform() === 'linux' || os.platform() === 'darwin') {

--- a/src/symlinkUtils.ts
+++ b/src/symlinkUtils.ts
@@ -1,0 +1,74 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface SymlinkMapping {
+    target: string;
+    link: string;
+}
+
+export function getLinuxArchitecture(): string {
+    const arch = os.arch();
+    switch (arch) {
+        case 'x64': return 'linux_x86_64';
+        case 'arm64': return 'linux_aarch64';
+        case 'arm': return 'linux_armv7l';
+        default: return 'linux_x86_64'; // fallback
+    }
+}
+
+export function getSymlinkMappings(): SymlinkMapping[] {
+    return [
+        { target: 'libespeak-ng.so.1.52.0.1', link: 'libespeak-ng.so.1' },
+        { target: 'libespeak-ng.so.1', link: 'libespeak-ng.so' },
+        { target: 'libonnxruntime.so.1.14.1', link: 'libonnxruntime.so' },
+        { target: 'libpiper_phonemize.so.1.2.0', link: 'libpiper_phonemize.so.1' },
+        { target: 'libpiper_phonemize.so.1', link: 'libpiper_phonemize.so' }
+    ];
+}
+
+export async function fixSymlinks(extensionPath: string): Promise<void> {
+    if (process.platform !== 'linux') {
+        return; // Only fix on Linux
+    }
+
+    const architecture = getLinuxArchitecture();
+    const binaryDir = path.join(extensionPath, 'piper', architecture);
+    
+    if (!fs.existsSync(binaryDir)) {
+        console.warn(`Piper binary directory not found: ${binaryDir}`);
+        return;
+    }
+
+    const symlinks = getSymlinkMappings();
+    
+    for (const { target, link } of symlinks) {
+        await createSymlink(binaryDir, target, link);
+    }
+}
+
+async function createSymlink(dir: string, target: string, link: string): Promise<void> {
+    const linkPath = path.join(dir, link);
+    const targetPath = path.join(dir, target);
+    
+    try {
+        // Check if target file exists
+        if (!fs.existsSync(targetPath)) {
+            console.warn(`Target file not found: ${targetPath}`);
+            return;
+        }
+        
+        // Remove existing file/symlink if it exists
+        if (fs.existsSync(linkPath)) {
+            await fs.promises.unlink(linkPath);
+        }
+        
+        // Create symbolic link
+        await fs.promises.symlink(target, linkPath);
+        console.log(`Created symlink: ${link} -> ${target}`);
+        
+    } catch (error) {
+        console.error(`Failed to create symlink ${link} -> ${target}:`, error);
+        // Don't throw - continue with other symlinks
+    }
+}


### PR DESCRIPTION
  - Add runtime symlink creation for Linux platforms
  - Detect architecture automatically (x86_64, aarch64, armv7l)
  - Fix corrupted symbolic links on extension activation
  - Add comprehensive error handling and logging
  - Resolves extension failure on all Linux distributions

  Fixes: Extension fails with 'Piper process exited with code: 127'
  Affects: All Linux users across all architectures