### PR TITLE
feat: add terminal selection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,19 @@ A Visual Studio Code extension that adds high-quality local text-to-speech capab
 ## Features
 
 - **Read Selected Text Aloud**: Easily convert selected text to speech with a single command
+- **Terminal Selection Support**: Select text in the integrated terminal and read it aloud via right-click context menu
 - **Multiple Languages and Voices**: Support for 40+ languages with 100+ voice options
 - **Local Processing**: All text-to-speech processing happens locally on your machine, with no data sent to external servers
 - **Cross-Platform**: Works on Windows and Linux
 - **Voice Management**: Download additional voices or remove existing ones
 - **API for Other Extensions**: Can be used by other VS Code extensions
+
+## Prerequisites
+
+### Linux
+Install a clipboard utility to read terminal selections:
+- **X11:** `sudo apt install xclip` (Debian/Ubuntu) or `sudo dnf install xclip` (Fedora)
+- **Wayland:** `sudo apt install wl-clipboard` (Debian/Ubuntu) or `sudo dnf install wl-clipboard` (Fedora)
 
 ## Installation
 
@@ -22,9 +30,15 @@ A Visual Studio Code extension that adds high-quality local text-to-speech capab
 
 ### Reading Text Aloud
 
+#### From Editor
 1. Select text in the editor
 2. Right-click and select "Read Aloud Text" from the context menu, or:
 3. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run "Piper TTS: Read Aloud Text"
+
+#### From Integrated Terminal
+1. Select text in the terminal (click and drag)
+2. Right-click and select "Read Aloud Text" from the context menu, or:
+3. Open the Command Palette and run "Piper TTS: Read Aloud Text"
 
 ### Stopping Playback
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Piper TTS",
   "description": "High-quality local text to speech with Piper",
   "icon": "images/icon.png",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/heyseth/Piper_TTS"
@@ -12,7 +12,9 @@
   "engines": {
     "vscode": "^1.98.0"
   },
-  "extensionKind": ["workspace"],
+  "extensionKind": [
+    "ui"
+  ],
   "enabledApiProposals": [],
   "categories": [
     "Other"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Piper TTS",
   "description": "High-quality local text to speech with Piper",
   "icon": "images/icon.png",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/heyseth/Piper_TTS"
@@ -83,10 +83,15 @@
           "group": "1_modification"
         }
       ],
-      "commandPalette": [
+      "terminal/context": [
         {
           "command": "piper-tts.readAloud",
-          "when": "editorHasSelection"
+          "group": "2_cutcopypaste@3"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "piper-tts.readAloud"
         },
         {
           "command": "piper-tts.stopPlayback"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -418,6 +418,33 @@ async function removeVoice(context: vscode.ExtensionContext) {
     }
 }
 
+// ponytail: xclip/wl-paste/pbpaste/clip.exe — the only reliable way to read terminal selections (VS Code's clipboard API ≠ system clipboard)
+async function readSystemClipboard(): Promise<string | undefined> {
+    const cmds = os.platform() === 'darwin'
+        ? [{ command: 'pbpaste', args: [] }]
+        : os.platform() === 'win32'
+            ? [{ command: 'powershell', args: ['-NoProfile', '-Command', 'Get-Clipboard'] }]
+            : [
+                { command: 'xclip', args: ['-selection', 'clipboard', '-out'] },
+                { command: 'wl-paste', args: ['-no-newline'] }, // ponytail: Wayland fallback
+            ];
+
+    for (const cmd of cmds) {
+        let out = '';
+        const result = await new Promise<string | undefined>((resolve) => {
+            try {
+                const proc = spawn(cmd.command, cmd.args);
+                proc.stdout.on('data', (d: Buffer) => out += d.toString());
+                proc.on('close', (code) => resolve(code === 0 ? out.trim() : undefined));
+                proc.on('error', () => resolve(undefined));
+            } catch {
+                resolve(undefined);
+            }
+        });
+        if (result !== undefined) return result;
+    }
+}
+
 // API interface that will be exposed to other extensions
 export interface PiperTTSApi {
     readText(text: string): Promise<void>;
@@ -601,10 +628,11 @@ export function activate(context: vscode.ExtensionContext): PiperTTSApi {
             text = editor.document.getText(editor.selection);
         }
 
-        // Fallback: copy terminal selection, then read clipboard
-        if (!text?.trim()) {
+        // Fallback: copy terminal selection, then read system clipboard
+        if (!text?.trim() && vscode.window.activeTerminal) {
             await vscode.commands.executeCommand('workbench.action.terminal.copySelection');
-            text = await vscode.env.clipboard.readText();
+            await new Promise(r => setTimeout(r, 100)); // ponytail: lets copy propagate to system clipboard
+            text = await readSystemClipboard();
         }
 
         if (!text?.trim()) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -593,16 +593,22 @@ export function activate(context: vscode.ExtensionContext): PiperTTSApi {
     context.subscriptions.push(selectVoiceDisposable);
 
     const readAloudDisposable = vscode.commands.registerCommand('piper-tts.readAloud', async () => {
+        let text: string | undefined;
+
+        // Try editor selection first
         const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            return;
+        if (editor) {
+            text = editor.document.getText(editor.selection);
         }
 
-        const selection = editor.selection;
-        const text = editor.document.getText(selection);
+        // Fallback: copy terminal selection, then read clipboard
+        if (!text?.trim()) {
+            await vscode.commands.executeCommand('workbench.action.terminal.copySelection');
+            text = await vscode.env.clipboard.readText();
+        }
 
-        if (!text) {
-            vscode.window.showInformationMessage('Please select some text to read aloud');
+        if (!text?.trim()) {
+            vscode.window.showInformationMessage('Please select some text to read aloud (copy terminal text first)');
             return;
         }
 


### PR DESCRIPTION
Adds terminal context menu and system clipboard integration for reading terminal selections aloud. Requires xclip (X11) or wl-clipboard (Wayland) on Linux.