### PR TITLE
Read aloud from the Markdown preview and from other extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Visual Studio Code extension that adds high-quality local text-to-speech capab
 ## Features
 
 - **Read Selected Text Aloud**: Easily convert selected text to speech with a single command
+- **Read from the Markdown Preview**: Select rendered text in the built-in Markdown preview and read it aloud with `Alt+A`
 - **Multiple Languages and Voices**: Support for 40+ languages with 100+ voice options
 - **Local Processing**: All text-to-speech processing happens locally on your machine, with no data sent to external servers
 - **Cross-Platform**: Works on Windows and Linux
@@ -24,11 +25,33 @@ A Visual Studio Code extension that adds high-quality local text-to-speech capab
 
 1. Select text in the editor
 2. Right-click and select "Read Aloud Text" from the context menu, or:
-3. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run "Piper TTS: Read Aloud Text"
+3. Press `Alt+A`, or:
+4. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run "Piper TTS: Read Aloud Text"
+
+### Reading Text in the Markdown Preview
+
+The built-in Markdown preview is a webview that VS Code owns, so extensions cannot
+add items to its right-click menu or read its selection directly. Piper TTS bridges
+this with a keyboard shortcut:
+
+1. Open a Markdown preview (`Ctrl+Shift+V`) and click into the preview pane
+2. Select the rendered text you want to hear
+3. Press `Alt+A`
+
+A small "🔊 Reading selection…" toast confirms the selection was picked up, and the
+text is read aloud. You can also run "Piper TTS: Read Aloud Selection (Markdown
+Preview)" from the Command Palette while the preview is focused.
+
+> Under the hood, a contributed preview script copies the current selection to the
+> clipboard when `Alt+A` is pressed and restores your previous clipboard contents
+> immediately afterwards. This is a workaround for the lack of a messaging channel
+> between extensions and the Markdown preview
+> ([microsoft/vscode#174080](https://github.com/microsoft/vscode/issues/174080)).
 
 ### Stopping Playback
 
 - Right-click in the editor and select "Stop Reading", or:
+- Press `Alt+Shift+A`, or:
 - Open the Command Palette and run "Piper TTS: Stop Reading"
 
 ### Changing Voices

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Visual Studio Code extension that adds high-quality local text-to-speech capab
 
 - **Read Selected Text Aloud**: Easily convert selected text to speech with a single command
 - **Read from the Markdown Preview**: Select rendered text in the built-in Markdown preview and read it aloud with `Alt+A`
+- **Read from Other Extensions**: Copy text from any panel or webview (AI chats like Claude, Cline, Codex, etc.) and read the clipboard aloud with `Ctrl+Alt+A`
 - **Multiple Languages and Voices**: Support for 40+ languages with 100+ voice options
 - **Local Processing**: All text-to-speech processing happens locally on your machine, with no data sent to external servers
 - **Cross-Platform**: Works on Windows and Linux
@@ -48,10 +49,20 @@ Preview)" from the Command Palette while the preview is focused.
 > between extensions and the Markdown preview
 > ([microsoft/vscode#174080](https://github.com/microsoft/vscode/issues/174080)).
 
+### Reading Text from Other Extensions
+
+The Markdown-preview limitation applies to other extensions' panels too — AI chats such as
+Claude, Cline, or Codex render their output in sandboxed webviews that Piper TTS cannot read
+directly. The workaround is the clipboard: select the text there, copy it, then read the
+clipboard aloud.
+
+1. Copy the text you want to hear (`Ctrl+C`)
+2. Press `Ctrl+Alt+A`, or run "Piper TTS: Read Aloud (Clipboard)" from the Command Palette
+
 ### Stopping Playback
 
 - Right-click in the editor and select "Stop Reading", or:
-- Press `Alt+Shift+A`, or:
+- Press `Alt+Shift+A` (works in the editor and while the Markdown preview is focused), or:
 - Open the Command Palette and run "Piper TTS: Stop Reading"
 
 ### Changing Voices

--- a/media/copySelection.js
+++ b/media/copySelection.js
@@ -88,7 +88,7 @@
     readClipboard().then(function (previous) {
       writeClipboard(payload).then(function () {
         if (payload) {
-          showToast('🔊 Reading selection…');
+          showToast('🔊 Reading selection… (Alt+Shift+A to stop)');
         } else {
           showToast('Select some text first');
         }
@@ -109,7 +109,7 @@
         // Clipboard write failed (permissions). Fall back to a copy of the DOM
         // selection, which is allowed inside the keydown user gesture.
         try { document.execCommand('copy'); } catch (e) { /* ignore */ }
-        showToast(payload ? '🔊 Reading selection…' : 'Select some text first');
+        showToast(payload ? '🔊 Reading selection… (Alt+Shift+A to stop)' : 'Select some text first');
       });
     });
   }

--- a/media/copySelection.js
+++ b/media/copySelection.js
@@ -1,0 +1,125 @@
+// Piper TTS — Markdown preview helper.
+//
+// The built-in Markdown preview is a webview owned by VS Code. Extensions cannot
+// message it directly (acquireVsCodeApi is already claimed by the core preview,
+// see microsoft/vscode#174080), so we bridge the current selection to the
+// extension host through the clipboard:
+//
+//   1. When the user presses the read shortcut (Alt+A) inside the preview, this
+//      script copies the current selection to the clipboard (or an empty string
+//      when nothing is selected, so the host can tell "no selection" apart from a
+//      stale clipboard).
+//   2. We do NOT preventDefault, so VS Code still forwards Alt+A to the host
+//      keybinding, which runs `piper-tts.readAloudPreview`. That command reads the
+//      clipboard and speaks it.
+//   3. Shortly afterwards we restore whatever was on the clipboard before, so the
+//      user's clipboard is left untouched.
+//
+// This file ships as a static asset (contributes.markdown.previewScripts) and runs
+// in the preview webview, so it uses plain browser APIs only.
+(function () {
+  // The preview re-injects contributed scripts on every content change; guard so we
+  // only ever attach one set of listeners per webview.
+  if (window.__piperTtsPreviewInit) {
+    return;
+  }
+  window.__piperTtsPreviewInit = true;
+
+  var RESTORE_DELAY_MS = 800; // must comfortably exceed the host's clipboard read
+
+  function getSelectedText() {
+    var sel = window.getSelection ? window.getSelection() : null;
+    return sel ? sel.toString() : '';
+  }
+
+  function writeClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+    return Promise.reject(new Error('clipboard API unavailable'));
+  }
+
+  function readClipboard() {
+    if (navigator.clipboard && navigator.clipboard.readText) {
+      return navigator.clipboard.readText();
+    }
+    return Promise.resolve(null);
+  }
+
+  function showToast(message) {
+    var id = 'piper-tts-toast';
+    var el = document.getElementById(id);
+    if (!el) {
+      el = document.createElement('div');
+      el.id = id;
+      el.style.cssText = [
+        'position:fixed',
+        'right:16px',
+        'bottom:16px',
+        'z-index:2147483647',
+        'padding:6px 12px',
+        'border-radius:6px',
+        'font-size:12px',
+        'font-family:var(--vscode-font-family, sans-serif)',
+        'color:var(--vscode-editorWidget-foreground, #ddd)',
+        'background:var(--vscode-editorWidget-background, #333)',
+        'border:1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.35))',
+        'box-shadow:0 2px 8px rgba(0,0,0,.35)',
+        'opacity:0',
+        'transition:opacity .15s ease',
+        'pointer-events:none'
+      ].join(';');
+      document.body.appendChild(el);
+    }
+    el.textContent = message;
+    // force reflow so the transition runs even on a reused element
+    void el.offsetWidth;
+    el.style.opacity = '1';
+    clearTimeout(el.__hideTimer);
+    el.__hideTimer = setTimeout(function () { el.style.opacity = '0'; }, 1400);
+  }
+
+  // Read shortcut: copy the selection so the host command can pick it up.
+  function handleReadShortcut() {
+    var selected = getSelectedText();
+    var payload = (selected && selected.trim()) ? selected : '';
+
+    // Snapshot the existing clipboard so we can put it back afterwards.
+    readClipboard().then(function (previous) {
+      writeClipboard(payload).then(function () {
+        if (payload) {
+          showToast('🔊 Reading selection…');
+        } else {
+          showToast('Select some text first');
+        }
+        if (previous !== null && previous !== undefined) {
+          setTimeout(function () {
+            // Only restore if we still hold our own payload (avoid clobbering a
+            // clipboard the user changed in the meantime).
+            readClipboard().then(function (current) {
+              if (current === payload) {
+                writeClipboard(previous).catch(function () {});
+              }
+            }).catch(function () {
+              writeClipboard(previous).catch(function () {});
+            });
+          }, RESTORE_DELAY_MS);
+        }
+      }).catch(function () {
+        // Clipboard write failed (permissions). Fall back to a copy of the DOM
+        // selection, which is allowed inside the keydown user gesture.
+        try { document.execCommand('copy'); } catch (e) { /* ignore */ }
+        showToast(payload ? '🔊 Reading selection…' : 'Select some text first');
+      });
+    });
+  }
+
+  document.addEventListener('keydown', function (e) {
+    // Alt+A (without Shift) — read the selection. Do not preventDefault, so the
+    // keybinding is still forwarded to the extension host.
+    if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey && (e.key === 'a' || e.key === 'A')) {
+      handleReadShortcut();
+    }
+    // Alt+Shift+A (stop) needs no clipboard work; the host keybinding handles it.
+  }, true);
+})();

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "activationEvents": [
     "onCommand:piper-tts.readAloud",
+    "onCommand:piper-tts.readAloudPreview",
     "onCommand:piper-tts.stopPlayback",
     "onCommand:piper-tts.selectVoice",
     "onCommand:piper-tts.downloadVoice",
@@ -46,6 +47,11 @@
       {
         "command": "piper-tts.readAloud",
         "title": "Read Aloud Text",
+        "category": "Piper TTS"
+      },
+      {
+        "command": "piper-tts.readAloudPreview",
+        "title": "Read Aloud Selection (Markdown Preview)",
         "category": "Piper TTS"
       },
       {
@@ -87,6 +93,10 @@
           "when": "editorHasSelection"
         },
         {
+          "command": "piper-tts.readAloudPreview",
+          "when": "activeCustomEditorId == 'vscode.markdown.preview.editor' || activeWebviewPanelId == 'vscode.markdown.preview.editor' || markdownPreviewFocus"
+        },
+        {
           "command": "piper-tts.stopPlayback"
         },
         {
@@ -99,7 +109,27 @@
           "command": "piper-tts.removeVoice"
         }
       ]
-    }
+    },
+    "keybindings": [
+      {
+        "command": "piper-tts.readAloud",
+        "key": "alt+a",
+        "when": "editorTextFocus && editorHasSelection"
+      },
+      {
+        "command": "piper-tts.readAloudPreview",
+        "key": "alt+a",
+        "when": "activeCustomEditorId == 'vscode.markdown.preview.editor' || activeWebviewPanelId == 'vscode.markdown.preview.editor' || markdownPreviewFocus"
+      },
+      {
+        "command": "piper-tts.stopPlayback",
+        "key": "alt+shift+a",
+        "when": "editorTextFocus || markdownPreviewFocus"
+      }
+    ],
+    "markdown.previewScripts": [
+      "./media/copySelection.js"
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "activationEvents": [
     "onCommand:piper-tts.readAloud",
     "onCommand:piper-tts.readAloudPreview",
+    "onCommand:piper-tts.readAloudClipboard",
     "onCommand:piper-tts.stopPlayback",
     "onCommand:piper-tts.selectVoice",
     "onCommand:piper-tts.downloadVoice",
@@ -52,6 +53,11 @@
       {
         "command": "piper-tts.readAloudPreview",
         "title": "Read Aloud Selection (Markdown Preview)",
+        "category": "Piper TTS"
+      },
+      {
+        "command": "piper-tts.readAloudClipboard",
+        "title": "Read Aloud (Clipboard)",
         "category": "Piper TTS"
       },
       {
@@ -94,7 +100,10 @@
         },
         {
           "command": "piper-tts.readAloudPreview",
-          "when": "activeCustomEditorId == 'vscode.markdown.preview.editor' || activeWebviewPanelId == 'vscode.markdown.preview.editor' || markdownPreviewFocus"
+          "when": "activeWebviewPanelId == 'markdown.preview' || activeCustomEditorId == 'vscode.markdown.preview.editor'"
+        },
+        {
+          "command": "piper-tts.readAloudClipboard"
         },
         {
           "command": "piper-tts.stopPlayback"
@@ -119,12 +128,16 @@
       {
         "command": "piper-tts.readAloudPreview",
         "key": "alt+a",
-        "when": "activeCustomEditorId == 'vscode.markdown.preview.editor' || activeWebviewPanelId == 'vscode.markdown.preview.editor' || markdownPreviewFocus"
+        "when": "activeWebviewPanelId == 'markdown.preview' || activeCustomEditorId == 'vscode.markdown.preview.editor'"
+      },
+      {
+        "command": "piper-tts.readAloudClipboard",
+        "key": "ctrl+alt+a"
       },
       {
         "command": "piper-tts.stopPlayback",
         "key": "alt+shift+a",
-        "when": "editorTextFocus || markdownPreviewFocus"
+        "when": "editorTextFocus || activeWebviewPanelId == 'markdown.preview' || activeCustomEditorId == 'vscode.markdown.preview.editor'"
       }
     ],
     "markdown.previewScripts": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -614,6 +614,40 @@ export function activate(context: vscode.ExtensionContext): PiperTTSApi {
     });
     context.subscriptions.push(readAloudDisposable);
 
+    // Read the current selection in the built-in Markdown preview.
+    //
+    // The preview is a VS Code-owned webview and extensions can't read its DOM or
+    // receive messages from contributed preview scripts (see microsoft/vscode#174080).
+    // Our contributed script (media/copySelection.js) copies the preview selection
+    // to the clipboard when Alt+A is pressed; this command — bound to the same Alt+A
+    // while the preview is focused — reads it back and speaks it. The preview script
+    // writes an empty string when nothing is selected so we can distinguish that from
+    // a stale clipboard, and restores the previous clipboard contents afterwards.
+    const readAloudPreviewDisposable = vscode.commands.registerCommand('piper-tts.readAloudPreview', async () => {
+        // Give the preview script a brief moment to place the selection on the clipboard.
+        await new Promise(resolve => setTimeout(resolve, 60));
+
+        let text = '';
+        try {
+            text = (await vscode.env.clipboard.readText()) || '';
+        } catch (error) {
+            console.error('Failed to read clipboard for preview read-aloud:', error);
+        }
+        text = text.trim();
+
+        if (!text) {
+            vscode.window.showInformationMessage('Select some text in the Markdown preview, then press Alt+A to read it aloud.');
+            return;
+        }
+
+        try {
+            await api.readText(text);
+        } catch (error) {
+            vscode.window.showErrorMessage('Error running text-to-speech: ' + (error instanceof Error ? error.message : String(error)));
+        }
+    });
+    context.subscriptions.push(readAloudPreviewDisposable);
+
     const stopDisposable = vscode.commands.registerCommand('piper-tts.stopPlayback', () => api.stopPlayback());
     context.subscriptions.push(stopDisposable);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -648,6 +648,32 @@ export function activate(context: vscode.ExtensionContext): PiperTTSApi {
     });
     context.subscriptions.push(readAloudPreviewDisposable);
 
+    // Read whatever is currently on the clipboard. This is the universal entry point for
+    // content that lives in another extension's webview (Claude, Cline, Codex chat, etc.):
+    // those webviews are sandboxed so we can't read their DOM, but the user can select
+    // text there, copy it, and trigger this command (Ctrl+Alt+A) to have it read aloud.
+    const readAloudClipboardDisposable = vscode.commands.registerCommand('piper-tts.readAloudClipboard', async () => {
+        let text = '';
+        try {
+            text = (await vscode.env.clipboard.readText()) || '';
+        } catch (error) {
+            console.error('Failed to read clipboard for read-aloud:', error);
+        }
+        text = text.trim();
+
+        if (!text) {
+            vscode.window.showInformationMessage('Clipboard is empty — copy some text first, then run Read Aloud (Clipboard).');
+            return;
+        }
+
+        try {
+            await api.readText(text);
+        } catch (error) {
+            vscode.window.showErrorMessage('Error running text-to-speech: ' + (error instanceof Error ? error.message : String(error)));
+        }
+    });
+    context.subscriptions.push(readAloudClipboardDisposable);
+
     const stopDisposable = vscode.commands.registerCommand('piper-tts.stopPlayback', () => api.stopPlayback());
     context.subscriptions.push(stopDisposable);
 


### PR DESCRIPTION
### Markdown preview
- Select rendered text in the built-in Markdown preview and press `Alt+A` to read it aloud. A contributed preview script bridges the selection to the extension host via the clipboard, since the preview webview is sandboxed (see microsoft/vscode#174080).
- **Fixes the `when` clauses:** the built-in preview (`Ctrl+Shift+V`) is a webview whose id is `markdown.preview`, and `markdownPreviewFocus` is not a real context key — so `Alt+A` / `Alt+Shift+A` previously never fired in the standard preview. They now use `activeWebviewPanelId == 'markdown.preview'` and work. `Alt+Shift+A` stops playback while the preview is focused.

### Read from other extensions (clipboard)
- New `piper-tts.readAloudClipboard` command on `Ctrl+Alt+A`: reads whatever is on the clipboard. Other extensions’ output (AI chats like Claude, Cline, Codex) lives in sandboxed webviews we can’t read directly, so the flow is: select there → copy → `Ctrl+Alt+A`.

### Notes
- Independent of the speed-control PR (#7).
- Tested on Windows and native Linux: `tsc` and `eslint` clean on both.